### PR TITLE
Content could be modified when calling jieba.add_guaranteed_wordlist multiple times

### DIFF
--- a/jseg/jieba.py
+++ b/jseg/jieba.py
@@ -139,9 +139,7 @@ class Jieba(Hmm):
 
         :param: lst: list of words.
         """
-        gw_num = self._gw_num
-        if gw_num == 0:
-            gw_num = 1
+        gw_num = self._gw_num + 1
         for num, word in enumerate(lst, gw_num):
             self._gw_num = num
             self._gw[word] = '_gw' + str(num) + '@'


### PR DESCRIPTION
```python
from jseg import Jieba
jieba = Jieba()
original_content = '從天津搭普通車於下午五點抵達唐山，立刻被接到工廠與杜管理、劉管理會面'
print(original_content)
jieba.add_guaranteed_wordlist(['抵達'])
res = jieba.seg(original_content)
seg_content = ''.join(res)
print(seg_content)
assert original_content == seg_content

jieba.add_guaranteed_wordlist(['到'])
res = jieba.seg(original_content)
seg_content = ''.join(res)
print(seg_content)
assert original_content == seg_content
```
Output:
```
DEBUG:jseg.jieba:loading default dictionary
DEBUG:jseg.jieba:find in dict: 抵達
DEBUG:jseg.jieba:find in dict: 到
DEBUG:jseg.jieba:find in dict: 到
從天津搭普通車於下午五點抵達唐山，立刻被接到工廠與杜管理、劉管理會面
從天津搭普通車於下午五點抵達唐山，立刻被接到工廠與杜管理、劉管理會面
從天津搭普通車於下午五點到唐山，立刻被接到工廠與杜管理、劉管理會面
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-79-1d769b475592> in <module>()
     13 seg_content = ''.join(res)
     14 print(seg_content)
---> 15 assert original_content == seg_content

AssertionError: 
```
``抵達`` is replaced by ``到`` when we call ``add_guaranteed_wordlist`` second time.

In ``class Jieba(Hmm):``
```python
    def add_guaranteed_wordlist(self, lst=None):
        """User-defined dictoinary.

        :param: lst: list of words.
        """
        gw_num = self._gw_num
        if gw_num == 0:
            gw_num = 1
        for num, word in enumerate(lst, gw_num):
            self._gw_num = num
            self._gw[word] = '_gw' + str(num) + '@'
            self._gwr['_gw' + str(num) + '@'] = word
```
If we call ``add_guaranteed_wordlist`` with input list of length 1 multiple times, several words will have same ``'_gw' + str(num) + '@'``, which causes problem when checking `` self._gwr['_gw' + str(num) + '@']``. Slight modification could fix the issue.